### PR TITLE
Replace os.system with subprocess in video module

### DIFF
--- a/own_package/plot/video.py
+++ b/own_package/plot/video.py
@@ -1,18 +1,31 @@
 import os
+import subprocess
 
 
 # Creates video using the image_path at video_path
 def make_video(image_path, video_path, framerate=5, zfill_n=5, theme="bright"):
-    video_command = f"ffmpeg -framerate {framerate} -i "
-    video_command += f"{image_path}_%0{zfill_n}d.png "
+    video_cmd = [
+        "ffmpeg",
+        "-framerate",
+        str(framerate),
+        "-i",
+        f"{image_path}_%0{zfill_n}d.png",
+    ]
 
     if theme == "bright":
-        video_command += f'-vf "pad=ceil(iw/2)*2:ceil(ih/2)*2, fps=25, format=yuv420p" '
+        video_cmd += [
+            "-vf",
+            "pad=ceil(iw/2)*2:ceil(ih/2)*2, fps=25, format=yuv420p",
+        ]
     elif theme == "dark":
-        video_command += f"-c copy "
+        video_cmd += ["-c", "copy"]
 
-    video_command += f"{video_path}.mp4"
+    video_cmd.append(f"{video_path}.mp4")
 
-    print(f"Command: {video_command}")
+    print("Command:", " ".join(video_cmd))
 
-    os.system(video_command)
+    result = subprocess.run(video_cmd, capture_output=True, text=True)
+    if result.returncode != 0:
+        raise RuntimeError(
+            f"Video creation failed with exit code {result.returncode}: {result.stderr}"
+        )

--- a/tests/plot/test_video.py
+++ b/tests/plot/test_video.py
@@ -1,0 +1,26 @@
+import sys
+import os
+from unittest.mock import patch
+
+cwd = os.path.dirname(__file__)
+for i in range(len(cwd.split("/"))):
+    if cwd.split("/")[i] == "own_package":
+        break
+
+package_abs_path = "/".join(cwd.split("/")[: i + 1]) + "/own_package/"
+
+sys.path.insert(0, f"{package_abs_path}plot/")
+
+import video as vid
+
+
+def test_make_video_error():
+    with patch("video.subprocess.run") as mock_run:
+        mock_run.return_value.returncode = 1
+        mock_run.return_value.stderr = "fail"
+        try:
+            vid.make_video("img", "out")
+            assert False, "Expected RuntimeError"
+        except RuntimeError as exc:
+            assert "fail" in str(exc)
+


### PR DESCRIPTION
## Summary
- use `subprocess.run` in `make_video`
- raise `RuntimeError` when ffmpeg fails
- add regression test for failure behaviour

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6846f9654e0c832e87e3a837ee4d43d9