### PR TITLE
Simplify periodic tiling and add tests

### DIFF
--- a/own_package/data_analysis/array_operations.py
+++ b/own_package/data_analysis/array_operations.py
@@ -126,28 +126,30 @@ def gaussian_filter(A, sigma=1.0):
 
 
 def make_array_periodic(arr):
-    shape = np.array(arr.shape)
+    """Tile a 3-D array three times along each axis.
 
-    # N_dim = len(shape)
+    Parameters
+    ----------
+    arr : np.ndarray
+        Input array. Must be three dimensional.
 
-    # shape = (shape / 1.1).astype(int)
-    padded_shape = shape * 3
-    padded_arr = np.zeros(padded_shape, dtype=arr.dtype)
-    if len(shape) == 3:
-        for i in range(3):
-            for j in range(3):
-                for k in range(3):
-                    padded_arr[
-                        shape[0] * i : shape[0] * (i + 1),
-                        shape[1] * j : shape[1] * (j + 1),
-                        shape[2] * k : shape[2] * (k + 1),
-                    ] = arr[: shape[0], : shape[1], : shape[2]]
-    else:
+    Returns
+    -------
+    np.ndarray
+        Tiled array with shape ``arr.shape * 3``.
+
+    Raises
+    ------
+    ValueError
+        If ``arr`` is not a 3-D array.
+    """
+
+    if arr.ndim != 3:
         raise ValueError(
-            "array_operations::surround_array(): Only 3D arrays are supported..."
+            "make_array_periodic(): Only 3D arrays are supported"
         )
 
-    return padded_arr
+    return np.tile(arr, (3, 3, 3))
 
 
 def radial_profile(arr, center=None, bins=10):

--- a/tests/data_analysis/test_array_operations.py
+++ b/tests/data_analysis/test_array_operations.py
@@ -12,6 +12,8 @@ package_abs_path = "/".join(cwd.split("/")[: i + 1]) + "/own_package/"
 sys.path.insert(0, f"{package_abs_path}data_analysis/")
 
 import array_operations as ao
+import numpy as np
+import pytest
 
 
 def test_dot_product():
@@ -23,3 +25,20 @@ def test_dot_product():
 
     assert output[0] == 0
     assert output[1] == 0
+
+
+def test_make_array_periodic():
+
+    arr = np.array([[[1, 2], [3, 4]]])
+
+    tiled = ao.make_array_periodic(arr)
+
+    assert np.array_equal(tiled, np.tile(arr, (3, 3, 3)))
+
+
+def test_make_array_periodic_invalid_dim():
+
+    arr = np.ones((2, 2))
+
+    with pytest.raises(ValueError):
+        ao.make_array_periodic(arr)


### PR DESCRIPTION
## Summary
- simplify `make_array_periodic` by using `np.tile`
- update unit tests for `make_array_periodic`
- install numpy, scipy and cmasher for tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6846f962b2c8832ebda43561e9545513